### PR TITLE
Change to cuda12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,11 @@ Bash convenience functions::
         if [ ! -z $2 ] ; then branch=$2; fi
 
         export CMBENVVERSION=$branch-$tag
+
+        module unload cudatoolkit # ignore the systemwide cudatoolkit to avoid version conflicts
+        module load cudatoolkit/12.2
+        module load cudnn/8.9.3_cuda12
+        module load cray-mpich craype-accel-nvidia80
         module use ${cmbprefix}/${CMBENVVERSION}/modulefiles
         module load cmbenv
         source ${cmbprefix}/${CMBENVVERSION}/conda/bin/activate

--- a/conf/conda-pkgs.sh
+++ b/conf/conda-pkgs.sh
@@ -10,15 +10,11 @@ conda config --set channel_priority flexible
 conda install --yes -c conda-forge -c anaconda -c nvidia -c defaults \
     astropy \
     camb \
-    cuda-nvcc \
-    cudatoolkit \
     emcee \
     fitsio \
     gputil \
     healpy \
     ipython \
-    jax \
-    jaxlib=*=*cuda* \
     joblib \
     jupyter \
     matplotlib \
@@ -30,7 +26,6 @@ conda install --yes -c conda-forge -c anaconda -c nvidia -c defaults \
     namaster \
     tqdm \
     meson \
- 
 
     
  && rm -rf $CONDADIR/pkgs/*

--- a/conf/perlmutter-env.sh
+++ b/conf/perlmutter-env.sh
@@ -14,6 +14,10 @@ export NTMAKE=8
 # needed for mpi4py
 # see https://docs.nersc.gov/development/languages/python/using-python-perlmutter
 module unload cudatoolkit # ignore the systemwide cudatoolkit to avoid version conflicts
+module load cudatoolkit/12.2
+module load cudnn/8.9.3_cuda12
+module load cray-mpich craype-accel-nvidia80
+
 export MPICC="cc -target-accel=nvidia80 -shared"
 
 for PRGENV in $(echo gnu intel cray nvidia)

--- a/conf/pip-pkgs.sh
+++ b/conf/pip-pkgs.sh
@@ -1,6 +1,9 @@
 # Install pip packages.
 echo Installing pip packages at $(date)
 
+# JAX install follows: https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#jax
+pip install --no-cache-dir "jax[cuda12]" "jaxlib" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+
 # see https://docs.nersc.gov/development/languages/python/parallel-python/
 pip install --force --no-cache-dir --no-binary=mpi4py mpi4py
 pip install cython

--- a/install.sh
+++ b/install.sh
@@ -79,8 +79,8 @@ sed -i 's@_CONDAPRGENV_@'"$CONDAPRGENV"'@g' cmbenv.module
 cp cmbenv.module $MODULEDIR/$CMBENVVERSION
 cp $topdir/cmbenv.modversion $MODULEDIR/.version_$CMBENVVERSION
 
-chgrp -R $GRP $MODULEDIR
-chmod -R u=rwX,g=rX,o-rwx $MODULEDIR
+# chgrp -R $GRP $MODULEDIR
+# chmod -R u=rwX,g=rX,o-rwx $MODULEDIR
 
 # All done
 echo Done at $(date)


### PR DESCRIPTION
Changes:

1. Use cudatoolkit12 from NERSC modules instead of installing from conda (which is in v11.8)
2. Loading cudatoolkit/12.2, cudnn/8.9.3_cuda12, cray-mpich, craype-accel-nvidia80.
3. Install jax[cuda12] and jaxlib in the way recommended by NERSC. Moved to pip install.

 